### PR TITLE
use alert_below and warn_below

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -98,12 +98,12 @@ class ResultServer(flask.Flask):
             if 'warn_above' in c:
                 c['warn_s'] = '>{}'.format(c['warn_above'])
             elif 'warn_below' in c:
-                c['warn_s'] = '<{}'.format(c['warn_above'])
+                c['warn_s'] = '<{}'.format(c['warn_below'])
 
             if 'alert_above' in c:
                 c['alert_s'] = '>{}'.format(c['alert_above'])
             elif 'alert_below' in c:
-                c['alert_s'] = '<{}'.format(c['alert_above'])
+                c['alert_s'] = '<{}'.format(c['alert_below'])
 
             if 'count' in c:
                 c['status'] = self.determine_status(c)


### PR DESCRIPTION
otherwise the checks using alert_below or warn_below will complain of:

TypeError: unorderable types: int() > str()

cc: @larsyencken 
