### PR TITLE
Output poll information using structured logs.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ jsonschema
 mysqlclient
 pyyaml
 jinja2-highlight
+structlog


### PR DESCRIPTION
Adds a dependency on `structlog`, and makes output from `poll.py` one-record-per-line JSON. This is meant to make the poll logs easier to work with over time.
